### PR TITLE
bugfix/replace for loop with next()

### DIFF
--- a/storage/sdk-search-items.ipynb
+++ b/storage/sdk-search-items.ipynb
@@ -251,11 +251,11 @@
     "items = UP42_client.get_items()\n",
     "\n",
     "# Print results\n",
-    "for item in items:\n",
-    "    print(f\"STAC item ID:   {item.id}\")\n",
-    "    print(f\"Order ID:       {item.properties.get('up42-user:id', 'Not available')}\")\n",
-    "    print(f\"User title:     {item.properties.get('up42-user:title', 'Not available')}\")\n",
-    "    print(f\"User tags:      {item.properties.get('up42-user:tags', 'Not available')}\\n\")"
+    "item=next(items)\n",
+    "print(f\"STAC item ID:   {item.id}\")\n",
+    "print(f\"Order ID:       {item.properties.get('up42-order:id', 'Not available')}\")\n",
+    "print(f\"User title:     {item.properties.get('up42-user:title', 'Not available')}\")\n",
+    "print(f\"User tags:      {item.properties.get('up42-user:tags', 'Not available')}\\n\")"
    ]
   },
   {


### PR DESCRIPTION
bugfix: replace `for` loop on `get_items()` interator, reducing load to our backend.
